### PR TITLE
Restore invisible brackets around nicknames

### DIFF
--- a/Data/Templates/newMessagePostedWithSender.mustache
+++ b/Data/Templates/newMessagePostedWithSender.mustache
@@ -25,14 +25,15 @@
 
 		<span class="message" ltype="{{lineType}}">
 			<span class="senderContainer">
-				<span class="sender"
+				<span class="beforeNickname swrapper"></span><span class="sender"
 					onclick="Textual.nicknameMaybeWasDoubleClicked(this)"
 					oncontextmenu="Textual.openStandardNicknameContextualMenu()"
 					mtype="{{nicknameType}}"
 					nickname="{{nickname}}"
 					{{#nicknameColorHashingEnabled}}
 						colornumber="{{nicknameColorNumber}}"
-					{{/nicknameColorHashingEnabled}}>{{formattedNickname}}</span>
+					{{/nicknameColorHashingEnabled}}>{{formattedNickname}}</span><span
+					class="afterNickname swrapper"></span>
 			</span>
 
 			<span class="innerMessage">

--- a/scripts.js
+++ b/scripts.js
@@ -254,12 +254,24 @@ Textual.handleEvent = function (event) {
 Textual.newMessagePostedToView = function (line) {
   'use strict';
   var message = document.getElementById('line-' + line);
-  var clone, elem, getEmbeddedImages, i, mode, messageText, sender, topic;
+  var clone, elem, getEmbeddedImages, i, mode, messageText, sender, topic, before, after;
 
   // reset the message count and previous nick, when you rejoin a channel
   if (message.getAttribute('ltype') !== 'privmsg') {
     rs.nick.count = 1;
     rs.nick.nick = undefined;
+  }
+
+  // decorate messages with hidden <nickname> and * nickname annotations for copying
+  if (message.getAttribute('ltype') === 'privmsg') {
+    before = message.getElementsByClassName('beforeNickname')[0];
+    after = message.getElementsByClassName('afterNickname')[0];
+    before.innerHTML = "&lt;";
+    after.innerHTML = "&gt;";
+  }
+  if (message.getAttribute('ltype') === 'action') {
+    before = message.getElementsByClassName('beforeNickname')[0];
+    before.innerHTML = "* ";
   }
 
   // if it's a private message, colorize the nick and then track the state and fade away the nicks if needed


### PR DESCRIPTION
When copying and pasting chat logs from Textual's window, the brackets help keep the text readable.

They were silently removed during the major overhaul in 796d320. Because they weren't mentioned at all in the commit message, my thought is that it might have been accidental—especially since the CSS was left in.
