### PR TITLE
Update Equinox for Textual 7.0.3

### DIFF
--- a/design.css
+++ b/design.css
@@ -241,9 +241,8 @@ body img {
   height: 25px;
 }
 
-
 /* Remember Line */
-div[id=mark] {
+#mark {
   position: relative;
   z-index: 295;
   margin-top: -1px;
@@ -257,29 +256,69 @@ body[dir=ltr] div[ltype=action] .sender:before {
   font-weight: bold;
   font-size: 80% !important;
   content: "●";
-
 }
 
-/* Historic / Log readback */
-
-#historic_messages {
-	transition: opacity 0.8s ease-in;
-	opacity: 0;
-	height: 0;
-	margin: 0;
-	padding: 0;
+/* Message buffer loading animation */
+.message_buffer_loading_indicator {
+	text-align: center;
+	height: 42px;
 }
 
-#historic_messages.loaded {
-	height: auto;
+.message_buffer_loading_indicator span {
+	font-family: Optima !important;
+	font-size: 35px;
+	font-weight: 600;
+	letter-spacing: 5px;
+	line-height: 43px;
+	color: #5a5a5a;
+	-webkit-animation: ellipsis-period 1.5s infinite;
+	animation: ellipsis-period 1.5s infinite;
 }
 
-#historic_messages[isreload="false"].loaded {
-	opacity: 0.6;
+.message_buffer_loading_indicator span:nth-child(1) {
+	-webkit-animation-delay: 0.0s;
+	animation-delay: 0.0s;
 }
 
-#historic_messages[isreload="true"].loaded {
-	opacity: 1.0;
+.message_buffer_loading_indicator span:nth-child(2) {
+	-webkit-animation-delay: 0.1s;
+	animation-delay: 0.1s;
+}
+
+.message_buffer_loading_indicator span:nth-child(3) {
+	-webkit-animation-delay: 0.2s;
+	animation-delay: 0.2s;
+}
+
+@keyframes ellipsis-period {
+	0% { opacity: 0.2; }
+	20% { opacity: 1.0; }
+	100% { opacity: 0.2; }
+}
+
+/* Message buffer session indicator */
+.message_buffer_session_indicator {
+	display: flex;
+	display: -webkit-flex;
+	padding: .5em 0;
+}
+
+.message_buffer_session_indicator > hr {
+	background: #444;
+	border: 0;
+	height: 1px;
+	margin-top: 0.6em;
+	flex: 1;
+	-webkit-flex: 1;
+}
+
+.message_buffer_session_indicator > span {
+	font-style: oblique;
+	margin: 0 1em;
+}
+
+.message_buffer_session_indicator + #mark {
+	display: none;
 }
 
 /* NOTICE/CTCP/WALLOPS */
@@ -635,7 +674,7 @@ body div.date > span {
   margin: 0 1em;
 }
 
-body div.date + div#mark, body div.date + div#historic_messages + div#mark {
+body div.date + div#mark {
   display: none;
 }
 

--- a/scripts.js
+++ b/scripts.js
@@ -204,20 +204,6 @@ function dateChange(e) {
     }
   };
 
-  // First, let's get the last line posted
-  var lastline = e.previousSibling;
-
-  if (lastline) {
-    // And if it's a mark or a previous date entry, let's remove it, we can use css + selectors for marks that follow
-    deleteLastlineDate(lastline);
-
-    // If the last line is the historic_messages div and its last child or previous sibling is a date, remove that too
-    if (lastline.id === 'historic_messages') {
-      deleteLastlineDate(lastline.lastChild);
-      deleteLastlineDate(lastline.previousSibling);
-    }
-  }
-
   // Create the date element: <div class="date"><hr /><span>...</span><hr /></div>
   var div = document.createElement('div');
   var span = document.createElement('span');
@@ -260,7 +246,7 @@ Textual.handleEvent = function (event) {
   }
 };
 
-Textual.newMessagePostedToView = function (line) {
+Textual.messageAddedToView = function (line, fromBuffer) {
   'use strict';
   var message = document.getElementById('line-' + line);
   var clone, elem, getEmbeddedImages, i, mode, messageText, sender, topic;
@@ -301,8 +287,11 @@ Textual.newMessagePostedToView = function (line) {
     // Copy the message into the hidden history
     clone = message.cloneNode(true);
     clone.removeAttribute('id');
-    rs.history.appendChild(clone);
 
+    if (fromBuffer === false) {
+      rs.history.appendChild(clone);
+    }
+   
     // Colorize it as well
     if (sender.getAttribute('coloroverride') !== 'true') {
       new NickColorGenerator(clone); // colorized the nick


### PR DESCRIPTION
• Changed CSS to use #mark instead of div[id=mark] because it just makes sense.
• Removed CSS and JavaScript related to the #historic_messages container. That container is no longer used to distinguish old messages and new messages.
• Added CSS for .message_buffer_session_indicator which is a marker, very simliar to that used for date changes, which indicates to the user where messages from the previous session end.
• Added CSS for .message_buffer_loading_indicator which is a loading indicator for when messages are being populated by scrolling upwards, which is a new feature in Textual 7.0.3.
• Changed to using new Textual.messageAddedToView callback so that the history container used by Equinox only modifies its children when a fresh message is received and not those being populated by scrolling upwards.

Documentation: https://help.codeux.com/textual/release-notes/Style-Developers%3A-Migrating-to-7.0.3.kb